### PR TITLE
Fix translation import for modern Django

### DIFF
--- a/hhcodingtask/users/models.py
+++ b/hhcodingtask/users/models.py
@@ -1,7 +1,10 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:  # Django<4.0 fallback
+    from django.utils.translation import ugettext_lazy as _
 
 
 class User(AbstractUser):


### PR DESCRIPTION
## Summary
- ensure users model imports `gettext_lazy`

## Testing
- `python -m py_compile hhcodingtask/users/models.py`
