### PR TITLE
Fix typo in production settings comment

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -156,7 +156,7 @@ AWS_PRELOAD_METADATA = True
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#logging
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
-# the site admins bon every HTTP 500 error when DEBUG=False.
+# the site admins on every HTTP 500 error when DEBUG=False.
 # See https://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = {


### PR DESCRIPTION
## Summary
- fix a typo in production settings

## Testing
- `pytest -q` *(fails: command not found)*